### PR TITLE
Add basic unit tests for agent modules

### DIFF
--- a/tests/test_agent_code_generator.py
+++ b/tests/test_agent_code_generator.py
@@ -1,0 +1,29 @@
+import importlib
+import pytest
+
+if importlib.util.find_spec("langchain_openai") is None:
+    pytest.skip("langchain_openai not available", allow_module_level=True)
+
+from agents.agent_code_generator import AgentCodeGenerator, llm
+
+class DummyResponse:
+    def __init__(self, text):
+        self.content = text
+
+def test_generate_code_clean(monkeypatch):
+    monkeypatch.setattr(llm, 'invoke', lambda *a, **k: DummyResponse("```python\nprint('hi')\n```"))
+    ag = AgentCodeGenerator()
+    code = ag.generate_code(
+        algorithm='ABOD',
+        data_path_train='train',
+        data_path_test='test',
+        algorithm_doc='doc',
+        input_parameters={},
+        package_name='pyod'
+    )
+    assert code.strip() == "print('hi')"
+
+def test_extract_init_params_dict():
+    txt = "```python\n{'a': 1}\n```"
+    result = AgentCodeGenerator._extract_init_params_dict(txt)
+    assert result == {'a': 1}

--- a/tests/test_agent_evaluator.py
+++ b/tests/test_agent_evaluator.py
@@ -1,0 +1,11 @@
+from agents.agent_evaluator import AgentEvaluator
+
+SCRIPT = """print('AUROC: 0.9')\nprint('AUPRC: 0.8')\nprint('Failed prediction at point [1, 2] with true label 0')"""
+
+def test_execute_code(tmp_path):
+    evaluator = AgentEvaluator()
+    cq = evaluator.execute_code(SCRIPT, 'dummy')
+    assert cq.auroc == 0.9
+    assert cq.auprc == 0.8
+    assert cq.error_points == [{'point': [1.0, 2.0], 'true_label': 0.0}]
+    assert cq.error_message == ''

--- a/tests/test_agent_info_miner.py
+++ b/tests/test_agent_info_miner.py
@@ -1,0 +1,32 @@
+import importlib
+import json
+import pytest
+
+if importlib.util.find_spec("openai") is None:
+    pytest.skip("openai not available", allow_module_level=True)
+
+from agents.agent_info_miner import AgentInfoMiner
+
+class DummyClient:
+    class Response:
+        def __init__(self, text):
+            self.output_text = text
+
+    def __init__(self, *a, **k):
+        pass
+
+    class responses:
+        @staticmethod
+        def create(*args, **kwargs):
+            return DummyClient.Response("doc text")
+
+
+def test_query_docs(monkeypatch, tmp_path):
+    monkeypatch.setattr('agents.agent_info_miner.OpenAI', lambda *a, **k: DummyClient())
+    miner = AgentInfoMiner()
+    doc = miner.query_docs('Algo', vectorstore=None, package_name='pyod', cache_path=str(tmp_path/"cache.json"))
+    assert doc == 'doc text'
+    # cache file should be written
+    with open(tmp_path/"cache.json", 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert 'Algo' in data

--- a/tests/test_agent_optimizer.py
+++ b/tests/test_agent_optimizer.py
@@ -1,0 +1,22 @@
+import importlib
+import pytest
+
+if importlib.util.find_spec("langchain") is None:
+    pytest.skip("langchain not available", allow_module_level=True)
+
+from agents.agent_optimizer import AgentOptimizer
+
+
+def test_extract_param_dict():
+    text = "Thought: ok\nAction: execute_code({'p': 1})"
+    assert AgentOptimizer._extract_param_dict(text) == {'p': 1}
+
+
+def test_find_float():
+    assert AgentOptimizer._find_float(r'AUROC:\s*([0-9.]+)', 'AUROC: 0.77') == 0.77
+
+
+def test_parse_errors():
+    text = 'Failed prediction at point [1,2] with true label 0'
+    pts = AgentOptimizer._parse_errors(text)
+    assert pts == [{'point': [1.0, 2.0], 'true_label': 0.0}]

--- a/tests/test_agent_processor.py
+++ b/tests/test_agent_processor.py
@@ -1,0 +1,15 @@
+import importlib
+import pytest
+
+if importlib.util.find_spec("openai") is None:
+    pytest.skip("openai not available", allow_module_level=True)
+
+from agents.agent_processor import AgentProcessor
+
+
+def test_extract_config(monkeypatch):
+    processor = AgentProcessor()
+    sample = 'FINAL: {"algorithm":["LOF"],"dataset_train":"train","dataset_test":"test","parameters":{}}'
+    monkeypatch.setattr(processor, 'get_chatgpt_response', lambda msgs: sample)
+    result = processor.extract_config('dummy')
+    assert result == {"algorithm": ["LOF"], "dataset_train": "train", "dataset_test": "test", "parameters": {}}

--- a/tests/test_agent_reviewer.py
+++ b/tests/test_agent_reviewer.py
@@ -1,0 +1,12 @@
+import importlib
+import pytest
+
+if importlib.util.find_spec("langchain_openai") is None:
+    pytest.skip("langchain_openai not available", allow_module_level=True)
+
+from agents.agent_reviewer import AgentReviewer
+
+
+def test_clean_markdown():
+    text = "```python\nprint('x')\n```"
+    assert AgentReviewer._clean_markdown(text) == "print('x')"

--- a/tests/test_agent_selector.py
+++ b/tests/test_agent_selector.py
@@ -1,0 +1,19 @@
+import importlib
+import pytest
+
+if importlib.util.find_spec("langchain_community") is None:
+    pytest.skip("langchain_community not available", allow_module_level=True)
+
+from agents.agent_selector import AgentSelector
+
+class DummySelector(AgentSelector):
+    def __init__(self):
+        pass
+
+
+def test_generate_tools_pyod():
+    sel = DummySelector.__new__(DummySelector)
+    sel.package_name = 'pyod'
+    tools = AgentSelector.generate_tools(sel, ['all'])
+    assert 'ECOD' in tools
+


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for agent modules
- safely skip tests when heavy dependencies are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492e428ef483338cbb61810baa63fe